### PR TITLE
add JPA entity models for Student, Teacher, Subject, and SchoolClass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,17 @@
     <artifactId>spring-boot-starter-web</artifactId>
 </dependency>
 
+<dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <scope>runtime</scope>
+</dependency>
+
+   <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/SufyanImran/Simplifi_test/model/SchoolClass.java
+++ b/src/main/java/com/SufyanImran/Simplifi_test/model/SchoolClass.java
@@ -1,0 +1,29 @@
+package com.SufyanImran.Simplifi_test.model;
+
+import jakarta.persistence.*;
+import java.util.Set;
+
+@Entity
+public class SchoolClass {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "schoolClass")
+    private Set<Student> students;
+
+    @ManyToMany(mappedBy = "classes")
+    private Set<Teacher> teachers;
+
+    @ManyToMany
+    @JoinTable(
+        name = "class_subject",
+        joinColumns = @JoinColumn(name = "class_id"),
+        inverseJoinColumns = @JoinColumn(name = "subject_id")
+    )
+    private Set<Subject> subjects;
+
+}

--- a/src/main/java/com/SufyanImran/Simplifi_test/model/Student.java
+++ b/src/main/java/com/SufyanImran/Simplifi_test/model/Student.java
@@ -1,0 +1,20 @@
+package com.SufyanImran.Simplifi_test.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Student{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String firstname;
+    private String lastname;
+    private String emailAddress;
+    private String phoneNumber;
+
+    @ManyToOne
+    @JoinColumn(name = "class_id")
+    private SchoolClass schoolClass;
+
+}

--- a/src/main/java/com/SufyanImran/Simplifi_test/model/Subject.java
+++ b/src/main/java/com/SufyanImran/Simplifi_test/model/Subject.java
@@ -1,0 +1,22 @@
+package com.SufyanImran.Simplifi_test.model;
+
+import jakarta.persistence.*;
+import java.util.Set;
+
+@Entity
+public class Subject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToMany(mappedBy = "subjects")
+    private Set<Teacher> teachers;
+
+    @ManyToMany(mappedBy = "subjects")
+    private Set<SchoolClass> classes;
+
+
+}

--- a/src/main/java/com/SufyanImran/Simplifi_test/model/Teacher.java
+++ b/src/main/java/com/SufyanImran/Simplifi_test/model/Teacher.java
@@ -1,0 +1,34 @@
+package com.SufyanImran.Simplifi_test.model;
+
+import jakarta.persistence.*;
+import java.util.Set;
+
+@Entity
+public class Teacher {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String firstname;
+    private String lastname;
+    private String emailAddress;
+    private String phoneNumber;
+
+    @ManyToMany
+    @JoinTable(
+        name = "teacher_class",
+        joinColumns = @JoinColumn(name = "teacher_id"),
+        inverseJoinColumns = @JoinColumn(name = "class_id")
+    )
+    private Set<SchoolClass> classes;
+
+
+    @ManyToMany
+    @JoinTable(
+        name = "teacher_subject",
+        joinColumns = @JoinColumn(name = "teacher_id"),
+        inverseJoinColumns = @JoinColumn(name = "subject_id")
+    )
+    private Set<Subject> subjects;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 spring.application.name=Simplifi-test
+
+server.port=8000
+
+spring.datasource.url=jdbc:mysql://localhost:3306/school_db
+spring.datasource.username=root
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
- Implemented @Entity classes with appropriate fields and relationships
- Set up many-to-many and many-to-one mappings using JPA annotations
- Applied package structure: com.SufyanImran.Simplifi_test.model
- Ensured compatibility with MySQL database via Spring Data JPA